### PR TITLE
[Refactor] 로그인 data 반환값 수정

### DIFF
--- a/footlog/src/hooks/login/useGetLogin.ts
+++ b/footlog/src/hooks/login/useGetLogin.ts
@@ -15,8 +15,11 @@ const useGetLogin = () => {
       api
         .get(`user/kakao/callback?code=${KAKAO_CODE}`)
         .then((res) => {
-          const data = res.data as loginResProps; // AxiosResponse의 data를 loginResProps로 단언
-          setToken(data.result.accessToken);
+          console.log('res!', res);
+          console.log('res.data!!', res.data);
+          //const data = res.data as loginResProps; // AxiosResponse의 data를 loginResProps로 단언
+          console.log('acccc', res.data.accessToken);
+          setToken(res.data.accessToken);
           setIsLoggedIn(true); // 로그인 성공 시 상태 업데이트
           console.log('로그인 성공');
           router.push('/onboarding');

--- a/footlog/src/types/login/loginProps.ts
+++ b/footlog/src/types/login/loginProps.ts
@@ -2,12 +2,12 @@ export interface loginResProps {
   isSuccess: boolean;
   code: string;
   message: string;
-  result: { accessToken: string; refreshToken: string };
+  data: { accessToken: string; refreshToken: string };
 }
 
 export interface loginErrorProps {
   isSuccess: boolean;
   code: string;
   message: string;
-  result: { accessToken: string; refreshToken: string };
+  data: { accessToken: string; refreshToken: string };
 }


### PR DESCRIPTION
## Related Issues

- close #25 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 코드 리팩토링

## 변경 사항 in Detail

- [x] 로그인 data 반환값 수정
```
export interface loginResProps {
  isSuccess: boolean;
  code: string;
  message: string;
  data: { accessToken: string; refreshToken: string };
}

export interface loginErrorProps {
  isSuccess: boolean;
  code: string;
  message: string;
  data: { accessToken: string; refreshToken: string };
}
```
크게 달라진 건 없고 여기 loginResProps랑 loginErrorProps 기존 result 반환값에서 data로 바꿨고
```
if (KAKAO_CODE) {
      api
        .get(`user/kakao/callback?code=${KAKAO_CODE}`)
        .then((res) => {
          console.log('res!', res);
          console.log('res.data!!', res.data);
          //const data = res.data as loginResProps; // AxiosResponse의 data를 loginResProps로 단언
          console.log('acccc', res.data.accessToken);
          setToken(res.data.accessToken);
          setIsLoggedIn(true); // 로그인 성공 시 상태 업데이트
          console.log('로그인 성공');
          router.push('/onboarding');
        })
```
여기 우선 타입 처리하는거 주석 처리했는데 아무리 해도 data.accessToken에 접근이 안 되더라구.. 그래서 그냥 `res.data.accessToken`로 접근했어..! 여긴 나중에 수정해야할 것 같은데 우선 로그인이 되는지 확인하는게 급해서 이렇게 처리했어!

https://github.com/user-attachments/assets/450a577d-f8c3-4372-ab86-daf3d12198b7




## 다음에 할 것

- [ ] api 연결 및 타입 처리
