### PR TITLE
Feat/#32/onboarding/prefer api

### DIFF
--- a/footlog/src/api/onboarding/api.ts
+++ b/footlog/src/api/onboarding/api.ts
@@ -1,0 +1,34 @@
+import axios, { AxiosInstance } from 'axios';
+import { getToken } from '@utils/token';
+
+const api: AxiosInstance = axios.create({
+  baseURL: process.env.NEXT_PUBLIC_ONBOARDING_API_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+export default api;
+
+// 응답 인터셉터
+// 항상 패칭 요청을 보내면 response.data 리턴
+api.interceptors.response.use(
+  function (response) {
+    return response.data;
+  },
+  // 에러 처리
+  async (error) => {
+    console.log(error.message);
+    return Promise.reject(error);
+  },
+);
+
+// 요청 인터셉터
+// 토큰이 필요한 모든 요청의 헤더에 토큰 넣어서 보내기
+api.interceptors.request.use((config) => {
+  const accessToken = getToken();
+  if (accessToken) {
+    config.headers['Authorization'] = `Bearer ${accessToken}`;
+  }
+  return config;
+});

--- a/footlog/src/api/onboarding/postPreferKeyword.ts
+++ b/footlog/src/api/onboarding/postPreferKeyword.ts
@@ -1,0 +1,18 @@
+import api from './api';
+import { Response } from 'types/common/Response';
+
+export interface PostPreferKeywordDataTypes {
+  firstOnboardingState: string[];
+  secondOnboardingState: string[];
+  thirdOnboardingState: string[];
+}
+
+export async function postPreferKeyword(props: PostPreferKeywordDataTypes): Promise<Response<any>> {
+  const { firstOnboardingState, secondOnboardingState, thirdOnboardingState } = props;
+
+  return await api.post(`/recommend/course`, {
+    firstOnboardingState,
+    secondOnboardingState,
+    thirdOnboardingState,
+  });
+}

--- a/footlog/src/app/onboarding/step3/page.tsx
+++ b/footlog/src/app/onboarding/step3/page.tsx
@@ -1,17 +1,23 @@
 'use client';
-import { useRecoilState } from 'recoil';
+import { useRecoilState, useRecoilValue } from 'recoil';
 import { useRouter } from 'next/navigation';
 import { LeftArrowIcon } from '@public/icon';
 import OnboardingTitle from '@components/onboarding/OnboardingTitle';
 import OnboardingKeywords from '@components/onboarding/OnboardingKeywords';
 import OnboardingBtn from '@components/onboarding/OnboardingBtn';
-import { thirdOnboardingState } from '@recoil/atom';
 import { onboardingIconsData } from '@core/onboardingIconsData';
+import { firstOnboardingState, secondOnboardingState, thirdOnboardingState } from '@recoil/atom';
+import usePostPreferKeyword from '@hooks/onboarding/usePostPreferKeyword';
 
 export default function page() {
   const router = useRouter();
   const [selectedKeywords, setSelectedKeywords] = useRecoilState(thirdOnboardingState);
   const currentIcons = onboardingIconsData.slice(6, 9);
+
+  const firstState = useRecoilValue(firstOnboardingState);
+  const secondState = useRecoilValue(secondOnboardingState);
+  const thirdState = useRecoilValue(thirdOnboardingState);
+  const { mutate: postPreferKeywordMutate } = usePostPreferKeyword();
 
   function handleBackBtn() {
     router.back();
@@ -31,6 +37,14 @@ export default function page() {
   }
 
   const isOnboardingBtnDisabled = selectedKeywords.length === 0;
+
+  function handleOnboardingBtn() {
+    postPreferKeywordMutate({
+      firstOnboardingState: firstState,
+      secondOnboardingState: secondState,
+      thirdOnboardingState: thirdState,
+    });
+  }
 
   return (
     <main className="relative flex h-full w-full flex-col px-24pxr pt-10pxr">
@@ -54,11 +68,7 @@ export default function page() {
         onKeywordSelect={handleKeywordSelect}
         iconsData={currentIcons}
       />
-      <OnboardingBtn
-        text="완료"
-        $disabled={isOnboardingBtnDisabled}
-        handleOnboardingBtn={() => router.push('/onboarding/step4')}
-      />
+      <OnboardingBtn text="완료" $disabled={isOnboardingBtnDisabled} handleOnboardingBtn={handleOnboardingBtn} />
     </main>
   );
 }

--- a/footlog/src/app/onboarding/step4/page.tsx
+++ b/footlog/src/app/onboarding/step4/page.tsx
@@ -1,13 +1,14 @@
 'use client';
 import { useEffect, useState } from 'react';
-import { useRouter } from 'next/navigation';
+import { useRecoilValue } from 'recoil';
 import { CheckIcon } from '@public/icon';
 import OnboardingTitle from '@components/onboarding/OnboardingTitle';
 import OnboardingBtn from '@components/onboarding/OnboardingBtn';
 import { MoonLoader } from 'react-spinners';
+import { firstOnboardingState, secondOnboardingState, thirdOnboardingState } from '@recoil/atom';
+import usePostPreferKeyword from '@hooks/onboarding/usePostPreferKeyword';
 
 export default function page() {
-  const router = useRouter();
   const [isOnboardingBtnDisabled, setIsOnboardingBtnDisabled] = useState(true); // 초기값 true로 설정
   const [titleText, setTitleText] = useState(
     <>
@@ -16,6 +17,11 @@ export default function page() {
       플로깅 코스를 찾고 있어요.
     </>,
   );
+
+  const firstState = useRecoilValue(firstOnboardingState);
+  const secondState = useRecoilValue(secondOnboardingState);
+  const thirdState = useRecoilValue(thirdOnboardingState);
+  const { mutate: postPreferKeywordMutate } = usePostPreferKeyword();
 
   // 일단 3초 후 바뀌게끔 해놨는데 나중에 api 연결로 바꿀게!
   useEffect(() => {
@@ -34,21 +40,25 @@ export default function page() {
     return () => clearTimeout(timer); // 컴포넌트 언마운트 시 타이머 정리
   }, []);
 
+  function handleOnboardingBtn() {
+    postPreferKeywordMutate({
+      firstOnboardingState: firstState,
+      secondOnboardingState: secondState,
+      thirdOnboardingState: thirdState,
+    });
+  }
+
   return (
-    <main className="px-24pxr pt-100pxr relative flex h-full w-full flex-col">
+    <main className="relative flex h-full w-full flex-col px-24pxr pt-100pxr">
       <OnboardingTitle text={titleText} />
-      <div className="pt-32pxr flex w-full items-center justify-center">
+      <div className="flex w-full items-center justify-center pt-32pxr">
         {isOnboardingBtnDisabled ? (
           <MoonLoader color="#05CBBE" size={70} speedMultiplier={0.5} />
         ) : (
           <CheckIcon /> // 버튼이 활성화되면 CheckIcon 출력
         )}
       </div>
-      <OnboardingBtn
-        text="시작하기"
-        $disabled={isOnboardingBtnDisabled}
-        handleOnboardingBtn={() => router.push('/home')}
-      />
+      <OnboardingBtn text="시작하기" $disabled={isOnboardingBtnDisabled} handleOnboardingBtn={handleOnboardingBtn} />
     </main>
   );
 }

--- a/footlog/src/app/onboarding/step4/page.tsx
+++ b/footlog/src/app/onboarding/step4/page.tsx
@@ -1,14 +1,13 @@
 'use client';
 import { useEffect, useState } from 'react';
-import { useRecoilValue } from 'recoil';
+import { useRouter } from 'next/navigation';
 import { CheckIcon } from '@public/icon';
 import OnboardingTitle from '@components/onboarding/OnboardingTitle';
 import OnboardingBtn from '@components/onboarding/OnboardingBtn';
 import { MoonLoader } from 'react-spinners';
-import { firstOnboardingState, secondOnboardingState, thirdOnboardingState } from '@recoil/atom';
-import usePostPreferKeyword from '@hooks/onboarding/usePostPreferKeyword';
 
 export default function page() {
+  const router = useRouter();
   const [isOnboardingBtnDisabled, setIsOnboardingBtnDisabled] = useState(true); // 초기값 true로 설정
   const [titleText, setTitleText] = useState(
     <>
@@ -17,11 +16,6 @@ export default function page() {
       플로깅 코스를 찾고 있어요.
     </>,
   );
-
-  const firstState = useRecoilValue(firstOnboardingState);
-  const secondState = useRecoilValue(secondOnboardingState);
-  const thirdState = useRecoilValue(thirdOnboardingState);
-  const { mutate: postPreferKeywordMutate } = usePostPreferKeyword();
 
   // 일단 3초 후 바뀌게끔 해놨는데 나중에 api 연결로 바꿀게!
   useEffect(() => {
@@ -40,14 +34,6 @@ export default function page() {
     return () => clearTimeout(timer); // 컴포넌트 언마운트 시 타이머 정리
   }, []);
 
-  function handleOnboardingBtn() {
-    postPreferKeywordMutate({
-      firstOnboardingState: firstState,
-      secondOnboardingState: secondState,
-      thirdOnboardingState: thirdState,
-    });
-  }
-
   return (
     <main className="relative flex h-full w-full flex-col px-24pxr pt-100pxr">
       <OnboardingTitle text={titleText} />
@@ -58,7 +44,11 @@ export default function page() {
           <CheckIcon /> // 버튼이 활성화되면 CheckIcon 출력
         )}
       </div>
-      <OnboardingBtn text="시작하기" $disabled={isOnboardingBtnDisabled} handleOnboardingBtn={handleOnboardingBtn} />
+      <OnboardingBtn
+        text="시작하기"
+        $disabled={isOnboardingBtnDisabled}
+        handleOnboardingBtn={() => router.push('/home')}
+      />
     </main>
   );
 }

--- a/footlog/src/hooks/onboarding/usePostPreferKeyword.ts
+++ b/footlog/src/hooks/onboarding/usePostPreferKeyword.ts
@@ -1,0 +1,22 @@
+'use client';
+import { useRouter } from 'next/navigation';
+import { useMutation } from '@tanstack/react-query';
+import { postPreferKeyword } from '@api/onboarding/postPreferKeyword';
+import { PostPreferKeywordDataTypes } from '@api/onboarding/postPreferKeyword';
+
+const usePostPreferKeyword = () => {
+  const router = useRouter();
+
+  return useMutation({
+    mutationFn: (data: PostPreferKeywordDataTypes) => postPreferKeyword(data),
+    onSuccess: (data) => {
+      console.log('온보딩 전송 성공', data);
+      router.push('/home'); // API 요청 성공 후 홈으로 이동
+    },
+    onError: (error) => {
+      console.log('온보딩 전송 실패', error);
+    },
+  });
+};
+
+export default usePostPreferKeyword;

--- a/footlog/src/hooks/onboarding/usePostPreferKeyword.ts
+++ b/footlog/src/hooks/onboarding/usePostPreferKeyword.ts
@@ -11,7 +11,7 @@ const usePostPreferKeyword = () => {
     mutationFn: (data: PostPreferKeywordDataTypes) => postPreferKeyword(data),
     onSuccess: (data) => {
       console.log('온보딩 전송 성공', data);
-      router.push('/home'); // API 요청 성공 후 홈으로 이동
+      router.push('/onboarding/step4');
     },
     onError: (error) => {
       console.log('온보딩 전송 실패', error);


### PR DESCRIPTION
## Related Issues

- close #32 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가


## 변경 사항 in Detail

재은이가 아직 수정 중에 있지만 hook 먼저 작성해봤옹.. 
재은이는 baser url 사용이 아니라서 axios instance를 onboarding 폴더 안에 재은이 버전으로 추가로 작성했어!

- [x] post 통신
  - api 폴더 안에 생성
  - postPreferKeyword.ts 
```
import api from './api';
import { Response } from 'types/common/Response';

export interface PostPreferKeywordDataTypes {
  firstOnboardingState: string[];
  secondOnboardingState: string[];
  thirdOnboardingState: string[];
}

export async function postPreferKeyword(props: PostPreferKeywordDataTypes): Promise<Response<any>> {
  const { firstOnboardingState, secondOnboardingState, thirdOnboardingState } = props;

  return await api.post(`/recommend/course`, {
    firstOnboardingState,
    secondOnboardingState,
    thirdOnboardingState,
  });
}
```

- [x] hook
  - hook 폴더 안에 생성
  - usePostPreferKeyword.ts 
```
'use client';
import { useRouter } from 'next/navigation';
import { useMutation } from '@tanstack/react-query';
import { postPreferKeyword } from '@api/onboarding/postPreferKeyword';
import { PostPreferKeywordDataTypes } from '@api/onboarding/postPreferKeyword';

const usePostPreferKeyword = () => {
  const router = useRouter();

  return useMutation({
    mutationFn: (data: PostPreferKeywordDataTypes) => postPreferKeyword(data),
    onSuccess: (data) => {
      console.log('온보딩 전송 성공', data);
      router.push('/onboarding/step4');
    },
    onError: (error) => {
      console.log('온보딩 전송 실패', error);
    },
  });
};

export default usePostPreferKeyword;
```


1. api 폴더에 **get** method일 경우 getPreferKeyword, getRecommend으로, 메소드가 **post**이면 postPreferKeyword, postRecommend로 **API 호출** 로직 작성 부분!


2. hooks 폴더에 getPreferKeyword였으면 use붙여서 useGetPreferKeyword, postPreferKeyword이었으면 usePostPreferKeyword 으로 use를 앞에 붙여서 구분하여 쿼리 상태를 반환!


3. 컴포넌트에는 use어쩌구 훅을 불러와서 사용하면 된다. (다른 컴포넌트에서 API 호출이 필요할 때 재사용하기 쉬움..!)

## 다음에 할 것

- [ ] 지역별 코스 찾기
