### PR TITLE
[Feature] 완주한 코스 api 가져오기

### DIFF
--- a/footlog/src/api/log/getCompletedList.ts
+++ b/footlog/src/api/log/getCompletedList.ts
@@ -1,0 +1,13 @@
+import api from 'api/api';
+import { Response } from 'types/common/Response';
+
+export interface CompletedListDtoDataTypes {
+  logId: number;
+  address: string;
+  name: string;
+}
+
+export async function getCompletedList(): Promise<Response<CompletedListDtoDataTypes[]>> {
+  const { data } = await api.get(`/log/completedList`);
+  return data;
+}

--- a/footlog/src/app/(CommonLayout)/log/page.tsx
+++ b/footlog/src/app/(CommonLayout)/log/page.tsx
@@ -6,7 +6,7 @@ export default function page() {
   return (
     <div>
       <MainSearchHeader />
-      <KakaoMap locations={['서울', '대구', '문경새재 도립공원']} />
+      <KakaoMap />
     </div>
   );
 }

--- a/footlog/src/components/log/KakaoMap.tsx
+++ b/footlog/src/components/log/KakaoMap.tsx
@@ -1,9 +1,13 @@
 import React, { useEffect, useState } from 'react';
 import 'react-kakao-maps-sdk';
 import MarkerModal from './MarkerModal';
+import useGetCompletedList from '@hooks/log/useGetCompletedList';
 
-const KakaoMap = ({ locations }: { locations: string[] }) => {
+const KakaoMap = () => {
   const [selectLocation, setSelectLocation] = useState<string | null>(null);
+
+  const { data: locations } = useGetCompletedList();
+  console.log('locations', locations);
 
   const handleSubmit = (text: String, images: (string | File)[]) => {
     console.log('text', text);
@@ -24,8 +28,8 @@ const KakaoMap = ({ locations }: { locations: string[] }) => {
         // 주소-좌표 변환 객체 생성
         const geocoder = new window.kakao.maps.services.Geocoder();
 
-        locations.forEach((location) => {
-          geocoder.addressSearch(location, function (result: any, status: any) {
+        locations?.data.forEach((location: any) => {
+          geocoder.addressSearch(location.address, function (result: any, status: any) {
             if (status === window.kakao.maps.services.Status.OK) {
               const latitude = Number(result[0].y);
               const longitude = Number(result[0].x);
@@ -45,14 +49,14 @@ const KakaoMap = ({ locations }: { locations: string[] }) => {
 
               const customOverlay = new window.kakao.maps.CustomOverlay({
                 position: coords,
-                content: `<div class="fonts-logLocations">${location}</div>`,
+                content: `<div class="fonts-logLocations">${location.name}</div>`,
                 yAnchor: 1, // 위치 조정 (마커 위에 텍스트를 표시하도록)
               });
 
               customOverlay.setMap(map);
 
               window.kakao.maps.event.addListener(marker, 'click', function () {
-                setSelectLocation(location);
+                setSelectLocation(location.address);
               });
             }
           });

--- a/footlog/src/hooks/log/useGetCompletedList.ts
+++ b/footlog/src/hooks/log/useGetCompletedList.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+import { getCompletedList } from '@api/log/getCompletedList';
+
+const useGetCompletedList = () => {
+  const queryKey = ['getCompletedList'];
+  const queryFn = () => getCompletedList();
+
+  const { data } = useQuery({
+    queryKey,
+    queryFn,
+  });
+
+  return { data };
+};
+
+export default useGetCompletedList;


### PR DESCRIPTION
## Related Issues

#41 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가

## 변경 사항 in Detail

- [x] 완주한 코스 api 가져오기

우선 너가 작성한 쿼리에 맞춰서
```
const useGetCompletedList = () => {
  const queryKey = ['getCompletedList'];
  const queryFn = () => getCompletedList();

  const { data } = useQuery({
    queryKey,
    queryFn,
  });

  return { data };
};

export default useGetCompletedList;
```

```
export interface CompletedListDtoDataTypes {
  logId: number;
  address: string;
  name: string;
}

export async function getCompletedList(): Promise<Response<CompletedListDtoDataTypes[]>> {
  const { data } = await api.get(`/log/completedList`);
  return data;
}
...
const { data: locations } = useGetCompletedList();
```

이런 식으로 작성했어!
음 백엔드에서 코드 좀 수정하느라 그거 수정한 것까지 반영했는데 별 거 아니고 백에서 주소만 줘가지구 지도에 보여줄 때는 장소 이름을 보여줘야 해서 그 데이터 추가하고 장소명이 뜨도록 바꿨어!

근데 문제는
아래 영상처럼 완주하기 누르고 바로 로그에 들어가면 보이는 경우가 있고 안 보이더라구..? 그래서 잘 보면 내가 새로고침 해..

https://github.com/user-attachments/assets/3c0cd907-4169-423d-bf74-7738dde1da94




## 다음에 할 것

- [ ] 사진, 글 업로드 api 연결
