### PR TITLE
[Feature] getLogDetails api 연결

### DIFF
--- a/footlog/src/api/log/getLogDetails.ts
+++ b/footlog/src/api/log/getLogDetails.ts
@@ -1,0 +1,20 @@
+import api from 'api/api';
+import { Response } from 'types/common/Response';
+
+export interface RequestPathVariable {
+  logId: number;
+}
+
+export interface LogDtoTypes {
+  logId: number;
+  address: string;
+  logContent: string;
+  photos: [];
+}
+
+export async function getLogDetails(props: RequestPathVariable): Promise<Response<LogDtoTypes>> {
+  const { logId } = props;
+
+  const { data } = await api.get(`/log/detail/${logId}`);
+  return data;
+}

--- a/footlog/src/components/log/KakaoMap.tsx
+++ b/footlog/src/components/log/KakaoMap.tsx
@@ -2,12 +2,22 @@ import React, { useEffect, useState } from 'react';
 import 'react-kakao-maps-sdk';
 import MarkerModal from './MarkerModal';
 import useGetCompletedList from '@hooks/log/useGetCompletedList';
+import useGetLogDetails from '@hooks/log/useGetLogDetails';
 
 const KakaoMap = () => {
   const [selectLocation, setSelectLocation] = useState<string | null>(null);
 
   const { data: locations } = useGetCompletedList();
   console.log('locations', locations);
+
+  const [logId, setLogId] = useState<number | null>(null);
+  console.log('lodId', logId);
+
+  // logId가 있을 때만 useGetLogDetails를 호출
+  const { data: details } = useGetLogDetails(logId ?? 0, {
+    enabled: !!logId, // logId가 있을 때만 API를 호출하도록 설정
+  });
+  console.log('details', details?.data);
 
   const handleSubmit = (text: String, images: (string | File)[]) => {
     console.log('text', text);
@@ -57,6 +67,7 @@ const KakaoMap = () => {
 
               window.kakao.maps.event.addListener(marker, 'click', function () {
                 setSelectLocation(location.name);
+                setLogId(location.logId);
               });
             }
           });
@@ -68,13 +79,13 @@ const KakaoMap = () => {
   return (
     <div>
       <div id="map" className="mt-68pxr h-688pxr w-full" />
-      {selectLocation && (
+      {selectLocation && logId && details?.data && (
         <MarkerModal
           location={selectLocation}
           onClose={() => setSelectLocation(null)}
           onSubmit={handleSubmit}
-          initialText="대구 풋!로그~"
-          initialImages={['https://cdn.crowdpic.net/detail-thumb/thumb_d_AE044C445F1F75281B4E7F996004555A.jpg']}
+          initialText={details?.data.logContent || ''}
+          initialImages={details?.data.photos || []}
         />
       )}
     </div>

--- a/footlog/src/components/log/KakaoMap.tsx
+++ b/footlog/src/components/log/KakaoMap.tsx
@@ -56,7 +56,7 @@ const KakaoMap = () => {
               customOverlay.setMap(map);
 
               window.kakao.maps.event.addListener(marker, 'click', function () {
-                setSelectLocation(location.address);
+                setSelectLocation(location.name);
               });
             }
           });

--- a/footlog/src/hooks/log/useGetLogDetails.ts
+++ b/footlog/src/hooks/log/useGetLogDetails.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+import { getLogDetails } from '@api/log/getLogDetails';
+
+const useGetLogDetails = (logId: number) => {
+  const queryKey = ['getLogDetails', logId];
+  const queryFn = () => getLogDetails({ logId });
+
+  const { data } = useQuery({
+    queryKey,
+    queryFn,
+  });
+
+  return { data };
+};
+
+export default useGetLogDetails;

--- a/footlog/src/hooks/log/useGetLogDetails.ts
+++ b/footlog/src/hooks/log/useGetLogDetails.ts
@@ -1,13 +1,14 @@
 import { useQuery } from '@tanstack/react-query';
 import { getLogDetails } from '@api/log/getLogDetails';
 
-const useGetLogDetails = (logId: number) => {
+const useGetLogDetails = (logId: number, options = {}) => {
   const queryKey = ['getLogDetails', logId];
   const queryFn = () => getLogDetails({ logId });
 
   const { data } = useQuery({
     queryKey,
     queryFn,
+    ...options,
   });
 
   return { data };


### PR DESCRIPTION
## Related Issues

#41 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가

## 변경 사항 in Detail

- [x] getLogDetails 연결

우선 코드부터 설명하자면
```
const useGetLogDetails = (logId: number, options = {}) => {
  const queryKey = ['getLogDetails', logId];
  const queryFn = () => getLogDetails({ logId });

  const { data } = useQuery({
    queryKey,
    queryFn,
    ...options,
  });

  return { data };
};
```
```
const [logId, setLogId] = useState<number | null>(null);
...
// logId가 있을 때만 useGetLogDetails를 호출
  const { data: details } = useGetLogDetails(logId ?? 0, {
    enabled: !!logId, // logId가 있을 때만 API를 호출하도록 설정
  });
```
깃발 하나를 클릭하면 그 위치에 해당하는 logId가 set되는데 타입이 number | null이어서 그냥 `useGetLogDetails(logId)` 만 하면 에러가 뜨더라구..
그래서 ?? 0 을 통해 null이거나 undifined인 경우에는 0으로 설정해줬어!
근데 이거만 하면 클릭을 안 한 코스들까지 api를 호출하면서 401에러가 떠서 `, { enabled: !!logId }` 라는걸 추가해줬어.
이게 useQuery의 옵션 기능이래! 쿼리를 활성화 또는 비활성화하는 데 사용된다고 하는데, !!를 통해서 logId가 존재하는 경우에만 true가 되면서 api를 호출하게 돼..!
그래서 맨 위의 코드 보면 `useGetLogDetails` 에 ` ...options`를 추가해줬는데 이건 useQuery에 여러 설정을 추가로 전달하고 싶을 때 사용한데!

- [x] 확인 영상

https://github.com/user-attachments/assets/69fca8ca-2c4e-4a82-967f-14e4a53b7319

그래서 더미 데이터 우선 넣어가지구 데이터있는 경우, 없는 경우 영상이야!


## 다음에 할 것

- [ ] 사진, 글 업로드
