### PR TITLE
[Feature] updateLog api 연결

### DIFF
--- a/footlog/src/api/log/updateLog.ts
+++ b/footlog/src/api/log/updateLog.ts
@@ -1,0 +1,29 @@
+import api from 'api/api';
+import { Response } from 'types/common/Response';
+
+export interface UpdateLogDtoTypes {
+    logContent: string;
+    existingUrls: string[];
+    newImages: File[];
+}
+
+export async function updateLog(logId: number, updateData: UpdateLogDtoTypes): Promise<Response<UpdateLogDtoTypes>>{
+    const formData = new FormData();
+
+    updateData.newImages.forEach((file) => {
+        formData.append('newImages', file);
+      });
+
+    // API 호출
+  const { data } = await api.patch(`/log/update/${logId}`, formData, {
+    params: {
+      logContent: updateData.logContent,
+      existingUrls: updateData.existingUrls,
+    },
+    headers: {
+      'Content-Type': 'multipart/form-data',
+    },
+  });
+
+  return data;
+  }

--- a/footlog/src/api/log/updateLog.ts
+++ b/footlog/src/api/log/updateLog.ts
@@ -2,28 +2,33 @@ import api from 'api/api';
 import { Response } from 'types/common/Response';
 
 export interface UpdateLogDtoTypes {
-    logContent: string;
-    existingUrls: string[];
-    newImages: File[];
+  logContent: string;
+  existingUrls: string[];
+  newImages: File[];
 }
 
-export async function updateLog(logId: number, updateData: UpdateLogDtoTypes): Promise<Response<UpdateLogDtoTypes>>{
-    const formData = new FormData();
+export async function updateLog(logId: number, updateData: UpdateLogDtoTypes): Promise<Response<UpdateLogDtoTypes>> {
+  const formData = new FormData();
 
-    updateData.newImages.forEach((file) => {
-        formData.append('newImages', file);
-      });
+  // logContent 추가
+  formData.append('logContent', updateData.logContent);
 
-    // API 호출
+  // 기존 이미지 URLs 추가
+  updateData.existingUrls.forEach((url) => {
+    formData.append('existingUrls', url);
+  });
+
+  // 새 이미지 파일 추가
+  updateData.newImages.forEach((file) => {
+    formData.append('newImages', file);
+  });
+
+  // API 호출
   const { data } = await api.patch(`/log/update/${logId}`, formData, {
-    params: {
-      logContent: updateData.logContent,
-      existingUrls: updateData.existingUrls,
-    },
     headers: {
       'Content-Type': 'multipart/form-data',
     },
   });
 
   return data;
-  }
+}

--- a/footlog/src/components/log/KakaoMap.tsx
+++ b/footlog/src/components/log/KakaoMap.tsx
@@ -3,6 +3,7 @@ import 'react-kakao-maps-sdk';
 import MarkerModal from './MarkerModal';
 import useGetCompletedList from '@hooks/log/useGetCompletedList';
 import useGetLogDetails from '@hooks/log/useGetLogDetails';
+import useUpdateLog from '@hooks/log/useUpdateLog';
 
 const KakaoMap = () => {
   const [selectLocation, setSelectLocation] = useState<string | null>(null);
@@ -19,9 +20,28 @@ const KakaoMap = () => {
   });
   console.log('details', details?.data);
 
-  const handleSubmit = (text: String, images: (string | File)[]) => {
-    console.log('text', text);
-    console.log('images', images);
+  const updateLogMutation = useUpdateLog(logId ?? 0);
+
+  const handleSubmit = (text: string, images: (string | File)[]) => {
+    const logContent = text || details?.data?.logContent || ''; // 기존 로그 내용을 유지
+    const existingUrls = images.filter((image) => typeof image === 'string') as string[]; // 기존 이미지 URL
+    const newImages = images.filter((image) => image instanceof File) as File[]; // 새로 업로드한 이미지 파일
+
+    const updateData = {
+      logContent,
+      existingUrls,
+      newImages,
+    };
+
+    // useUpdateLog의 mutation 함수 호출
+    updateLogMutation.mutate(updateData, {
+      onSuccess: (response) => {
+        console.log('Log updated successfully', response);
+      },
+      onError: (error) => {
+        console.error('Error updating log:', error);
+      },
+    });
   };
 
   useEffect(() => {

--- a/footlog/src/hooks/log/useUpdateLog.ts
+++ b/footlog/src/hooks/log/useUpdateLog.ts
@@ -1,0 +1,19 @@
+import { useMutation, UseMutationResult } from '@tanstack/react-query';
+import { updateLog, UpdateLogDtoTypes } from '@api/log/updateLog';
+import { Response } from 'types/common/Response';
+
+const useUpdateLog = (
+  logId: number,
+): UseMutationResult<Response<UpdateLogDtoTypes>, Error, UpdateLogDtoTypes, unknown> => {
+  return useMutation<Response<UpdateLogDtoTypes>, Error, UpdateLogDtoTypes>({
+    mutationFn: (updateData: UpdateLogDtoTypes) => updateLog(logId, updateData),
+    onSuccess: (data) => {
+      console.log('성공', data);
+    },
+    onError: (error) => {
+      console.log('실패', error);
+    },
+  });
+};
+
+export default useUpdateLog;


### PR DESCRIPTION
## Related Issues

- close #41 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가

## 변경 사항 in Detail

- [x] updateLog api 작성
```
export async function updateLog(logId: number, updateData: UpdateLogDtoTypes): Promise<Response<UpdateLogDtoTypes>> {
  const formData = new FormData();

  // logContent 추가
  formData.append('logContent', updateData.logContent);

  // 기존 이미지 URLs 추가
  updateData.existingUrls.forEach((url) => {
    formData.append('existingUrls', url);
  });

  // 새 이미지 파일 추가
  updateData.newImages.forEach((file) => {
    formData.append('newImages', file);
  });
```
`updateLog`에서 하나 설명해줄 부분은 `const formData = new FormData();` 여기야!
`FormData` 는 파일을 포함한 데이터를 서버로 전송할 때 사용하는 내장 객체래.

백에서 내가 데이터 주는 api 구현할 때 삭제, 업데이트 등을 한 번에 합쳐놔서 프론트에서 처리하는 로직이 좀 복잡해졌는데..
간단하게만 설명하면 위의 코드에서 logContent는 기록 중 글에 해당하고 existingUrls는 서버로부터 받은 기존 이미지 urls들이야. 그리고 newImages는 추가하는 이미지!

```
const useUpdateLog = (
  logId: number,
): UseMutationResult<Response<UpdateLogDtoTypes>, Error, UpdateLogDtoTypes, unknown> => {
  return useMutation<Response<UpdateLogDtoTypes>, Error, UpdateLogDtoTypes>({
    mutationFn: (updateData: UpdateLogDtoTypes) => updateLog(logId, updateData),
    onSuccess: (data) => {
      console.log('성공', data);
    },
    onError: (error) => {
      console.log('실패', error);
    },
  });
};
```
`useMutation`은 혜연이 너도 쓴 것처럼 알겠지만 리액트 쿼리에서 비동기 데이터 처리(POST, PUT, PATCH, DELETE 등)할 때 사용하는 훅이야! `mutationFn`은 이 훅에서 실제 비동기 작업 수행하는 함수!

- [x] updateLog api 연결
```
const updateLogMutation = useUpdateLog(logId ?? 0);

  const handleSubmit = (text: string, images: (string | File)[]) => {
    const logContent = text.trim() === '' ? '' : text; // 빈 문자열로 처리하고 싶을 때
    const existingUrls = images.filter((image) => typeof image === 'string') as string[]; // 기존 이미지 URL
    const newImages = images.filter((image) => image instanceof File) as File[]; // 새로 업로드한 이미지 파일

    const updateData = {
      logContent,
      existingUrls,
      newImages,
    };

    // useUpdateLog의 mutation 함수 호출
    updateLogMutation.mutate(updateData, {
      onSuccess: (response) => {
        console.log('Log updated successfully', response);
      },
      onError: (error) => {
        console.error('Error updating log:', error);
      },
    });
  };
```
그래서 위와 같이 사용했는데.. 굳이 간단하게 설명하자면 `handleSubmit` 함수에서 파라미터인 images에 existingUrls와 newImages를 하나의 배열에 함께 주거든..? `MarkerModal`이라는 컴포넌트에서 사용해!
그래서 filter로 type이 string이면 existingUrls로, File이면 newImages로 빼서 `updateLogMutation.mutate`에 전달했어!

- [x] 확인 영상
- 기존 기록이 있는 경우

https://github.com/user-attachments/assets/e479b79f-6cb9-4f3f-ac23-d4d54722b53e


- 기존 기록이 없는 경우 추가 / 기록 모두 삭제

https://github.com/user-attachments/assets/7e733e07-947c-468c-9be9-3b4ad409dd39


근데 여전히 새로고침해야 반영되고 있어서..! 그 refetch 필요할 것 같아..!

## 다음에 할 것

- [ ] 마이페이지 api 연결
