### PR TITLE
Feat/#52/log/refetch

### DIFF
--- a/footlog/src/app/(CommonLayout)/home/details/[id]/page.tsx
+++ b/footlog/src/app/(CommonLayout)/home/details/[id]/page.tsx
@@ -46,6 +46,7 @@ export default function page() {
         onSuccess: () => {
           // 성공적으로 저장한 후, course details를 다시 fetch
           queryClient.invalidateQueries({ queryKey: ['getCourseDetails', courseIdNumber] });
+          queryClient.invalidateQueries({ queryKey: ['getCompletedList'] });
         },
       },
     );

--- a/footlog/src/components/log/KakaoMap.tsx
+++ b/footlog/src/components/log/KakaoMap.tsx
@@ -1,4 +1,5 @@
 import React, { useEffect, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 import 'react-kakao-maps-sdk';
 import MarkerModal from './MarkerModal';
 import useGetCompletedList from '@hooks/log/useGetCompletedList';
@@ -6,6 +7,7 @@ import useGetLogDetails from '@hooks/log/useGetLogDetails';
 import useUpdateLog from '@hooks/log/useUpdateLog';
 
 const KakaoMap = () => {
+  const queryClient = useQueryClient();
   const [selectLocation, setSelectLocation] = useState<string | null>(null);
 
   const { data: locations } = useGetCompletedList();
@@ -37,6 +39,7 @@ const KakaoMap = () => {
     updateLogMutation.mutate(updateData, {
       onSuccess: (response) => {
         console.log('Log updated successfully', response);
+        queryClient.invalidateQueries({ queryKey: ['getLogDetails', logId] });
       },
       onError: (error) => {
         console.error('Error updating log:', error);


### PR DESCRIPTION
## Related Issues

- close #52 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 오류 수정


## 변경 사항 in Detail

❗ refetch 관련
- 데이터에 변경 사항이 있어서 최신 데이터로 다시 가져와야할 경우(post를 하거나, update를 하거나 해서 데이터에 변경사항이 생길 경우)

- onSuccess 안에 queryClient.invalidateQueries에 useGetCourseDetails의 쿼리키 값을 넣어줌으로써 refetch해옴!

- ReactQueryProvider.tsx에서 기본 0인 staleTime을 1분으로 맞춰놨기에 1분마다 다시 fetching해오지만 이런 식으로 바로 refetch를 해야할 때 쓰는 코드

- queryClient.invalidateQueries 이용해서 쿼리키 값에 해당하는 데이터를 invalidate 시키고, 그러면 해당 데이터가 즉각 stale 상태(데이터가 만료된 상태)가 되어 refetching된다!

1. `import { useQueryClient } from '@tanstack/react-query';` 이렇게 import한 후에,
2. `const queryClient = useQueryClient(); ` Query Client 인스턴스를 가져와서 
3. `queryClient.invalidateQueries({ queryKey: ['getCompletedList'] });` 이렇게 쿼리키를 넣어서 쓰면 됩니당

[캐시로 움직이는 리액트쿼리 작동 원리](https://mycodings.fly.dev/blog/2023-09-17-react-query-cachetime-staletime-refetch-poll)
[리액트쿼리 개념 및 기본 사용법](https://bongra.tistory.com/499)
[react-query 사용시 invalidateQueries를 이용해 캐싱 값 refetch하기](https://velog.io/@stakbucks/react-query-%EC%82%AC%EC%9A%A9%EC%8B%9C-invalidateQueries%EB%A5%BC-%EC%9D%B4%EC%9A%A9%ED%95%B4-%EC%BA%90%EC%8B%B1-%EA%B0%92-refetch%ED%95%98%EA%B8%B0)

## 다음에 할 것

- [ ] 다음에 할 것
