### PR TITLE
[Feat] 마이페이지 저장 목록, 최근 확인한 코스 api 연결

### DIFF
--- a/footlog/src/api/mypage/getRecentCourseList.ts
+++ b/footlog/src/api/mypage/getRecentCourseList.ts
@@ -1,15 +1,8 @@
 import api from 'api/api';
 import { Response } from 'types/common/Response';
+import { CourseResponseDtoDataTypes } from 'types/common/CommonTypes';
 
-export interface RecentCourseListDtoDataTypes {
-  course_id: number;
-  image: string;
-  area: string;
-  name: string;
-  isSave: boolean;
-}
-
-export async function getRecentCourseList(): Promise<Response<RecentCourseListDtoDataTypes[]>> {
+export async function getRecentCourseList(): Promise<Response<CourseResponseDtoDataTypes[]>> {
   const { data } = await api.get(`/course/recent`);
   return data;
 }

--- a/footlog/src/api/mypage/getRecentCourseList.ts
+++ b/footlog/src/api/mypage/getRecentCourseList.ts
@@ -1,0 +1,15 @@
+import api from 'api/api';
+import { Response } from 'types/common/Response';
+
+export interface RecentCourseListDtoDataTypes {
+  course_id: number;
+  image: string;
+  area: string;
+  name: string;
+  isSave: boolean;
+}
+
+export async function getRecentCourseList(): Promise<Response<RecentCourseListDtoDataTypes[]>> {
+  const { data } = await api.get(`/course/recent`);
+  return data;
+}

--- a/footlog/src/api/mypage/getSaveCourseList.ts
+++ b/footlog/src/api/mypage/getSaveCourseList.ts
@@ -1,0 +1,15 @@
+import api from 'api/api';
+import { Response } from 'types/common/Response';
+
+export interface SaveCourseListDtoDataTypes {
+  course_id: number;
+  image: string;
+  area: string;
+  name: string;
+  isSave: boolean;
+}
+
+export async function getSaveCourseList(): Promise<Response<SaveCourseListDtoDataTypes[]>> {
+  const { data } = await api.get(`/course/save_list`);
+  return data;
+}

--- a/footlog/src/api/mypage/getSaveCourseList.ts
+++ b/footlog/src/api/mypage/getSaveCourseList.ts
@@ -1,15 +1,8 @@
 import api from 'api/api';
 import { Response } from 'types/common/Response';
+import { CourseResponseDtoDataTypes } from 'types/common/CommonTypes';
 
-export interface SaveCourseListDtoDataTypes {
-  course_id: number;
-  image: string;
-  area: string;
-  name: string;
-  isSave: boolean;
-}
-
-export async function getSaveCourseList(): Promise<Response<SaveCourseListDtoDataTypes[]>> {
+export async function getSaveCourseList(): Promise<Response<CourseResponseDtoDataTypes[]>> {
   const { data } = await api.get(`/course/save_list`);
   return data;
 }

--- a/footlog/src/app/(CommonLayout)/mypage/page.tsx
+++ b/footlog/src/app/(CommonLayout)/mypage/page.tsx
@@ -12,10 +12,7 @@ export default function page() {
   console.log('saveCourseList', saveCourseList);
   console.log('recentCourseList', recentCourseList);
 
-  if (!saveCourseList?.data) {
-    return <></>;
-  }
-  if (!recentCourseList?.data) {
+  if (!saveCourseList?.data || !recentCourseList?.data) {
     return <></>;
   }
 

--- a/footlog/src/app/(CommonLayout)/mypage/page.tsx
+++ b/footlog/src/app/(CommonLayout)/mypage/page.tsx
@@ -1,9 +1,18 @@
+'use client';
 import MypageContainer from '@components/mypage/MypageContainer';
-import RecentCourseContainer from '@components/common/RecentCourseContainer';
-import { recommendCoursesData } from '@core/recommendCoursesData';
+//import RecentCourseContainer from '@components/common/RecentCourseContainer';
+//import { recommendCoursesData } from '@core/recommendCoursesData';
 import { Flag2Icon } from '@public/icon';
+import useGetSaveCourseList from '@hooks/mypage/useGetSaveCourseList';
 
 export default function page() {
+  const { data: saveCourseList } = useGetSaveCourseList();
+  console.log('saveCourseList', saveCourseList);
+
+  if (!saveCourseList?.data) {
+    return <></>;
+  }
+
   return (
     <div className="mt-16pxr flex h-full w-full flex-col overflow-y-auto">
       <section className="ml-24pxr h-174pxr">
@@ -32,8 +41,8 @@ export default function page() {
 
       <div className="h-8pxr w-393pxr bg-gray-1" />
 
-      <MypageContainer title="저장 목록" courses={recommendCoursesData} />
-      <RecentCourseContainer />
+      <MypageContainer title="저장 목록" courses={saveCourseList?.data} />
+      {/* <RecentCourseContainer /> */}
 
       <div className="h-8pxr w-393pxr bg-gray-1" />
 

--- a/footlog/src/app/(CommonLayout)/mypage/page.tsx
+++ b/footlog/src/app/(CommonLayout)/mypage/page.tsx
@@ -1,15 +1,21 @@
 'use client';
 import MypageContainer from '@components/mypage/MypageContainer';
-//import RecentCourseContainer from '@components/common/RecentCourseContainer';
+import RecentCourseContainer from '@components/common/RecentCourseContainer';
 //import { recommendCoursesData } from '@core/recommendCoursesData';
 import { Flag2Icon } from '@public/icon';
 import useGetSaveCourseList from '@hooks/mypage/useGetSaveCourseList';
+import useGetRecentCourseList from '@hooks/mypage/useGetRecentCourseList';
 
 export default function page() {
   const { data: saveCourseList } = useGetSaveCourseList();
+  const { data: recentCourseList } = useGetRecentCourseList();
   console.log('saveCourseList', saveCourseList);
+  console.log('recentCourseList', recentCourseList);
 
   if (!saveCourseList?.data) {
+    return <></>;
+  }
+  if (!recentCourseList?.data) {
     return <></>;
   }
 
@@ -42,13 +48,13 @@ export default function page() {
       <div className="h-8pxr w-393pxr bg-gray-1" />
 
       <MypageContainer title="저장 목록" courses={saveCourseList?.data} />
-      {/* <RecentCourseContainer /> */}
+      <RecentCourseContainer courses={recentCourseList?.data} />
 
       <div className="h-8pxr w-393pxr bg-gray-1" />
 
       <div className="ml-24pxr">
         <div className="font-mypageDetail mt-20pxr text-gray-8">선호도 재설정</div>
-        <div className="font-mypageDetai mt-20pxr text-gray-4">로그아웃</div>
+        <div className="font-mypageDetai mt-20pxr text-gray-4">회원 탈퇴</div>
       </div>
     </div>
   );

--- a/footlog/src/app/(CommonLayout)/mypage/save/page.tsx
+++ b/footlog/src/app/(CommonLayout)/mypage/save/page.tsx
@@ -12,7 +12,8 @@ export default function page() {
       <ListHeader title="저장 목록" />
       <section className="mt-68pxr flex flex-col gap-24pxr pt-12pxr">
         {course.map((course) => (
-          <BigLocationCard key={course.id} course={course} />
+          // <BigLocationCard key={course.id} course={course} />
+          <div></div>
         ))}
       </section>
     </main>

--- a/footlog/src/components/common/RecentCourseContainer.tsx
+++ b/footlog/src/components/common/RecentCourseContainer.tsx
@@ -1,14 +1,26 @@
 import CoursesSlider from '@components/common/CoursesSlider/CoursesSlider';
-import { RecommendCoursesDataTypes } from 'types/common/CommonTypes';
-import { recommendCoursesData } from '@core/recommendCoursesData';
+//import { RecommendCoursesDataTypes } from 'types/common/CommonTypes';
+//import { recommendCoursesData } from '@core/recommendCoursesData';
+import { CourseResponseDtoDataTypes } from 'types/common/CommonTypes';
 
-export default function RecentCourseContainer() {
-  const courses: RecommendCoursesDataTypes[] = recommendCoursesData;
+interface RecentCourseContainerProps {
+  courses: CourseResponseDtoDataTypes[];
+}
+
+export default function RecentCourseContainer(props: RecentCourseContainerProps) {
+  const { courses } = props;
 
   return (
     <section className="flex w-full flex-col py-28pxr pl-24pxr">
       <h2 className="fonts-recommendTitle">최근 확인한 코스</h2>
-      <CoursesSlider courses={courses} />
+
+      {courses && courses.length > 0 ? (
+        <CoursesSlider courses={courses} />
+      ) : (
+        <div>
+          <div className="fonts-mypageNull mb-57pxr ml-92pxr mt-71pxr">최근 확인한 코스가 없습니다.</div>
+        </div>
+      )}
     </section>
   );
 }

--- a/footlog/src/components/mypage/MypageContainer.tsx
+++ b/footlog/src/components/mypage/MypageContainer.tsx
@@ -1,12 +1,12 @@
 'use client';
 import { useRouter } from 'next/navigation';
-import { RecommendCoursesDataTypes } from 'types/common/CommonTypes';
+import { CourseResponseDtoDataTypes } from 'types/common/CommonTypes';
 import CoursesSlider from '@components/common/CoursesSlider/CoursesSlider';
 import { MypageRightArrowIcon } from '@public/icon';
 
 interface MypageContainerProps {
   title: string;
-  courses: RecommendCoursesDataTypes[];
+  courses: CourseResponseDtoDataTypes[];
 }
 
 export default function MypageContainer(props: MypageContainerProps) {

--- a/footlog/src/components/mypage/MypageContainer.tsx
+++ b/footlog/src/components/mypage/MypageContainer.tsx
@@ -11,14 +11,13 @@ interface MypageContainerProps {
 
 export default function MypageContainer(props: MypageContainerProps) {
   const { title, courses } = props;
+  console.log('courrrrr', courses);
   const router = useRouter();
-
-  const isSaved = true;
 
   return (
     <section className="ml-24pxr flex w-full flex-col">
       <section className="flex w-full flex-col py-20pxr">
-        {isSaved ? (
+        {courses && courses.length > 0 ? (
           <div>
             {' '}
             <section className="flex w-full items-center justify-between">

--- a/footlog/src/hooks/mypage/useGetRecentCourseList.ts
+++ b/footlog/src/hooks/mypage/useGetRecentCourseList.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+import { getRecentCourseList } from '@api/mypage/getRecentCourseList';
+
+const useGetRecentCourseList = () => {
+  const queryKey = ['getRecentCourseList'];
+  const queryFn = () => getRecentCourseList();
+
+  const { data } = useQuery({
+    queryKey,
+    queryFn,
+  });
+
+  return { data };
+};
+
+export default useGetRecentCourseList;

--- a/footlog/src/hooks/mypage/useGetSaveCourseList.ts
+++ b/footlog/src/hooks/mypage/useGetSaveCourseList.ts
@@ -1,0 +1,16 @@
+import { useQuery } from '@tanstack/react-query';
+import { getSaveCourseList } from '@api/mypage/getSaveCourseList';
+
+const useGetSaveCourseList = () => {
+  const queryKey = ['getSaveCourseList'];
+  const queryFn = () => getSaveCourseList();
+
+  const { data } = useQuery({
+    queryKey,
+    queryFn,
+  });
+
+  return { data };
+};
+
+export default useGetSaveCourseList;


### PR DESCRIPTION
## Related Issues

#40 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가

## 변경 사항 in Detail

- [x] 저장 목록 api 연결
- [x] 최근 확인한 코스 api 연결

둘 다 그냥 get으로 받는 거라 이전 코드들이랑 크게 다른 부분은 없어! 그냥 배열 길이 0이면 저장한 코스 / 확인한 코스 없다고 뜨게끔 했엉!
근데 둘 다 refetch 필요할 것 같아..! refetch는 그냥 나중에 싹 몰아서 해버릴까...흠냐

https://github.com/user-attachments/assets/6d671db3-dc5b-4c5d-b978-c12cda32a1ae


## 다음에 할 것

- [ ] 유저 정보 api 연결
