### PR TITLE
Design/#54/loading/UI

### DIFF
--- a/footlog/src/app/loading.tsx
+++ b/footlog/src/app/loading.tsx
@@ -6,7 +6,7 @@ interface LoadingPageProps {
   text: ReactNode;
 }
 
-export default function page(props: LoadingPageProps) {
+export default function Loading(props: LoadingPageProps) {
   const { text } = props;
 
   return (
@@ -27,3 +27,5 @@ const text = (
     잠시만 기다려주세요...
   </>
 );
+
+// <Suspense fallback={<Loading text={text} />} /> 이런 식으로 사용

--- a/footlog/src/app/loading/page.tsx
+++ b/footlog/src/app/loading/page.tsx
@@ -1,0 +1,29 @@
+import { MoonLoader } from 'react-spinners';
+import OnboardingTitle from '@components/onboarding/OnboardingTitle';
+import { ReactNode } from 'react';
+
+interface LoadingPageProps {
+  text: ReactNode;
+}
+
+export default function page(props: LoadingPageProps) {
+  const { text } = props;
+
+  return (
+    <main className="relative flex h-full w-full flex-col items-center pt-100pxr">
+      <section className="flex flex-col items-center gap-8pxr pt-12pxr">
+        <OnboardingTitle text={text} />
+        <MoonLoader color="#05cbbe" size={70} speedMultiplier={0.5} />
+      </section>
+    </main>
+  );
+}
+
+// 사용 예시
+const text = (
+  <>
+    사용자 정보를 가져오고 있습니다.
+    <br />
+    잠시만 기다려주세요...
+  </>
+);


### PR DESCRIPTION
## Related Issues

- close #54

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] CSS 등 스타일 변경


## 변경 사항 in Detail

- [x] loading.tsx 페이지 추가

  - 페이지 전체에서 로딩이 걸리는 건 Next가 자동으로 loading.tsx를 보여준당
  -  우리가 로딩페이지를 직접 지정해서 띄우고 싶은 경우에는 Suspense를 활용해서 `<Suspense fallback={<Loading text={text} />} />` 이런 식으로 사용하면 될 것 같아!!

  - 그래서 일단 text를 props로 전달받도록 해놨는데 흠 이건 로딩이 어디어디에 필요한지 보고 수정해야할 것 같아

  - [Next.js-페이지-로딩-처리하기](https://velog.io/@mjieun/Next.js-%ED%8E%98%EC%9D%B4%EC%A7%80-%EB%A1%9C%EB%94%A9-%EC%B2%98%EB%A6%AC%ED%95%98%EA%B8%B0-app-router)
  - [Next의 loading.tsx와 error.tsx with Suspense](https://shortcoding.tistory.com/563)

## 다음에 할 것

- [ ] 다음에 할 것
