### PR TITLE
[Feature] 기존 로그인 유저의 경우 선호도 코스 api 호출로 라우팅

### DIFF
--- a/footlog/src/hooks/login/useGetLogin.ts
+++ b/footlog/src/hooks/login/useGetLogin.ts
@@ -7,7 +7,7 @@ import { setToken } from '@utils/token';
 const useGetLogin = () => {
   const KAKAO_CODE = typeof window !== 'undefined' ? new URL(window.location.href).searchParams.get('code') : null;
   const router = useRouter();
-  const [_, setIsLoggedIn] = useState(false);
+  const [isLoggedIn, setIsLoggedIn] = useState(false);
 
   useEffect(() => {
     if (KAKAO_CODE) {
@@ -35,6 +35,29 @@ const useGetLogin = () => {
         });
     }
   }, [KAKAO_CODE, router]);
+
+  useEffect(() => {
+    if (isLoggedIn) {
+      api
+        .get(`course/recommend`)
+
+        .then((res) => {
+          if (res.data) {
+            if (res.data.isSuccess === true) {
+              console.log('코스 가져오기 성공');
+              router.push('/home');
+            }
+          }
+        })
+        .catch((err) => {
+          console.log(err);
+          if (err.data.isSuccess === false) {
+            console.log('코스 가져오기 실패');
+            router.push('/onboarding');
+          }
+        });
+    }
+  }, [isLoggedIn, router]);
 };
 
 export default useGetLogin;


### PR DESCRIPTION
## Related Issues

- close #56 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가


## 변경 사항 in Detail

- [x] 기존 로그인 유저의 경우 코스 가져오기 api 호출 성공 유무로 라우팅
  - 온보딩 선호도 조사로 받는 "나를 위한 코스 추천" API 호출 성공 유무로 온보딩 했는지 안했는지 판단했어!

  - 그래서 온보딩까지 진행한 기존 회원일 경우에 홈화면으로 이동하도록 바꿨어!

  - 근데 일단 로딩 페이지 관련해서 next에서 제공하는 로딩 말고 우리가 직접 지정해주는 걸로 바꿔야할 것 같당.. ㅠㅠ 할 거 진짜 많다 ㅠㅠㅋㅋ

## 다음에 할 것

- [ ] 로딩 관련 수정
