### PR TITLE
[Feat] 마이페이지 관련 모든 api 연결 완료

### DIFF
--- a/footlog/src/api/mypage/deleteUser.ts
+++ b/footlog/src/api/mypage/deleteUser.ts
@@ -1,0 +1,7 @@
+import api from 'api/api';
+import { Response } from 'types/common/Response';
+
+export async function deleteUser(): Promise<Response<any>> {
+  const { data } = await api.delete(`/user/withdraw`);
+  return data;
+}

--- a/footlog/src/app/(CommonLayout)/mypage/page.tsx
+++ b/footlog/src/app/(CommonLayout)/mypage/page.tsx
@@ -7,11 +7,15 @@ import useGetRecentCourse from '@hooks/common/useGetRecentCourse';
 import useGetUserInfo from '@hooks/mypage/useGetUserInfo';
 import React, { useEffect, useState } from 'react';
 import { useRecoilCallback } from 'recoil';
+import useDeleteUser from '@hooks/mypage/useDeleteUser';
+import { useRouter } from 'next/navigation';
 
 export default function page() {
+  const router = useRouter();
   const { data: saveCourseList } = useGetSaveCourseList();
   const { data: recentCourseList } = useGetRecentCourse();
   const { data: userInfo } = useGetUserInfo();
+  const { mutate: deleteUser } = useDeleteUser();
 
   console.log('userInfo', userInfo);
 
@@ -39,6 +43,10 @@ export default function page() {
     return <></>;
   }
 
+  const handleDeleteUser = () => {
+    deleteUser();
+    router.push('/login');
+  };
   const renderFlagIcon = () => {
     switch (stamp) {
       case 1:
@@ -95,7 +103,9 @@ export default function page() {
 
       <div className="ml-24pxr">
         <div className="font-mypageDetail mt-20pxr text-gray-8">선호도 재설정</div>
-        <div className="font-mypageDetai mt-20pxr text-gray-4">회원 탈퇴</div>
+        <button className="font-mypageDetai mt-20pxr text-gray-4" onClick={handleDeleteUser}>
+          회원 탈퇴
+        </button>
       </div>
     </div>
   );

--- a/footlog/src/app/(CommonLayout)/mypage/page.tsx
+++ b/footlog/src/app/(CommonLayout)/mypage/page.tsx
@@ -1,7 +1,7 @@
 'use client';
 import MypageContainer from '@components/mypage/MypageContainer';
 import RecentCourseContainer from '@components/common/RecentCourseContainer/RecentCourseContainer';
-import { Flag1Icon, Flag2Icon, Flag3Icon, Flag4Icon, Flag5Icon } from '@public/icon';
+import { Flag0Icon, Flag1Icon, Flag2Icon, Flag3Icon, Flag4Icon, Flag5Icon } from '@public/icon';
 import useGetSaveCourseList from '@hooks/mypage/useGetSaveCourseList';
 import useGetRecentCourse from '@hooks/common/useGetRecentCourse';
 import useGetUserInfo from '@hooks/mypage/useGetUserInfo';
@@ -20,7 +20,7 @@ export default function page() {
   console.log('userInfo', userInfo);
 
   const [level, setLevel] = useState<number>(1);
-  const [stamp, setStamp] = useState<number>(1);
+  const [stamp, setStamp] = useState<number>(0);
 
   useEffect(() => {
     if (userInfo?.data?.level) {
@@ -36,7 +36,7 @@ export default function page() {
         setLevel(5);
       }
     }
-    setStamp(userInfo?.data?.stampCount || 1);
+    setStamp(userInfo?.data?.stampCount || 0);
   }, [userInfo?.data?.level]);
 
   if (!saveCourseList?.data || !recentCourseList?.data || !userInfo?.data) {
@@ -49,6 +49,8 @@ export default function page() {
   };
   const renderFlagIcon = () => {
     switch (stamp) {
+      case 0:
+        return <Flag0Icon />;
       case 1:
         return <Flag1Icon />;
       case 2:
@@ -59,8 +61,6 @@ export default function page() {
         return <Flag4Icon />;
       case 5:
         return <Flag5Icon />;
-      default:
-        return <Flag1Icon />;
     }
   };
 
@@ -71,9 +71,6 @@ export default function page() {
 
         <div className="mt-27pxr flex">
           <div className="mt-5pxr">
-            {/* <svg xmlns="http://www.w3.org/2000/svg" width="80" height="80" viewBox="0 0 80 80" fill="none">
-              <circle opacity="0.5" cx="40" cy="40" r="40" fill="#D9D9D9" />
-            </svg> */}
             <img
               src={userInfo.data.profileImg}
               alt="profile"
@@ -102,10 +99,16 @@ export default function page() {
       <div className="h-8pxr w-393pxr bg-gray-1" />
 
       <div className="ml-24pxr">
-        <div className="font-mypageDetail mt-20pxr text-gray-8">선호도 재설정</div>
-        <button className="font-mypageDetai mt-20pxr text-gray-4" onClick={handleDeleteUser}>
-          회원 탈퇴
-        </button>
+        <div>
+          <button className="font-mypageDetail mt-20pxr text-gray-8" onClick={() => router.push('/onboarding')}>
+            선호도 재설정
+          </button>
+        </div>
+        <div>
+          <button className="font-mypageDetai mt-20pxr text-gray-4" onClick={handleDeleteUser}>
+            회원 탈퇴
+          </button>
+        </div>
       </div>
     </div>
   );

--- a/footlog/src/hooks/mypage/useDeleteUser.ts
+++ b/footlog/src/hooks/mypage/useDeleteUser.ts
@@ -1,0 +1,18 @@
+import { useMutation, UseMutationResult } from '@tanstack/react-query';
+import { deleteUser } from '@api/mypage/deleteUser';
+import { Response } from 'types/common/Response';
+
+// useDeleteUser 훅에 mutationFn 명시
+const useDeleteUser = (): UseMutationResult<Response<any>, Error, void, unknown> => {
+  return useMutation<Response<any>, Error, void>({
+    mutationFn: deleteUser,
+    onSuccess: (data) => {
+      console.log('User successfully deleted:', data);
+    },
+    onError: (error) => {
+      console.error('Error deleting user:', error.message);
+    },
+  });
+};
+
+export default useDeleteUser;


### PR DESCRIPTION
## Related Issues

- close #40 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 오류 수정

## 변경 사항 in Detail

- [x] 회원 탈퇴
- deleteUser, useDeleteUser
- 회원 탈퇴하면 로그인 페이지로 이동하게 했어!

https://github.com/user-attachments/assets/2dc06858-a5de-4d0a-a98f-6b7dd2deecb0

영상처럼 회원 탈퇴를 하면 로그인 페이지로 이동하고 온보딩으로 잘 넘어가! 디비 확인해보면 선호도 데이터 바뀌는 걸로 봤을 때, 잘 처리되고 있는 것 같아.
근데 회원 탈퇴해도 로그인 세션이 남아있는지 바로 로그인이 되고 있긴 한데..! 이 부분은 큰 문제 없으면 그냥 진행해도 될 것 같구.. 얘기해봐야할듯!
추가적으로 혜연이 너가 말한 탈퇴 시 깃발 개수 0개로 바뀌어야 하는 거 반영했어! ㅎㅎ

- [x] 선호도 재설정

https://github.com/user-attachments/assets/3f3bced1-9eae-40eb-9b1a-3db607bafe1a

선호도 재설정 클릭 시 온보딩으로 라우팅하게 했어! 프론트에서 받는 추천 코스도 바뀌는 거 영상에서도 보듯 확인할 수 있고, 디비에서도 값 바뀌는지 확인했엉~!

- [x] 레벨 바뀌는 것


https://github.com/user-attachments/assets/2c643d07-7fe5-42e9-adb0-dfeebdbf97d7

이전 pr에서 사진으로 해놓은 것 영상으로 다시 올려봤어!
refetch는 나중에 한 번에 다 해야할듯..! ㅎㅎ...




## 다음에 할 것

- [ ] refetch 및 추가적인 수정 사항
