### PR TITLE
Feat/#37/list/infinity scroll

### DIFF
--- a/footlog/next.config.mjs
+++ b/footlog/next.config.mjs
@@ -1,7 +1,6 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   images: {
-    //domains: ['image.tmdb.org'],
     remotePatterns: [
       { protocol: 'https', hostname: '**' },
       { protocol: 'http', hostname: '**' },

--- a/footlog/src/api/home/details/getCourseDetails.ts
+++ b/footlog/src/api/home/details/getCourseDetails.ts
@@ -9,6 +9,9 @@ export interface CourseDetailDtoDataTypes {
   summary: string;
   address: string;
   tel: string;
+  telName: string;
+  charge: string;
+  homepage: string;
   isSave: boolean;
   isComplete: boolean;
 }

--- a/footlog/src/app/(CommonLayout)/home/details/[id]/page.tsx
+++ b/footlog/src/app/(CommonLayout)/home/details/[id]/page.tsx
@@ -43,14 +43,18 @@ export default function Page() {
   const { refetch: refetchBigCourse } = useGetRegionalCourse(regionIdNumber ? regionIdNumber : 1);
 
   useEffect(() => {
-    const previousUrl = document.referrer; // 이전 URL 가져오기
-    const previousPathname = new URL(previousUrl).pathname; // URL의 경로만 가져오기
+    const previousUrl = localStorage.getItem('previousUrl');
+    if (previousUrl) {
+      const previousPathname = new URL(previousUrl).pathname; // URL의 경로만 가져오기
+      console.log('Previous pathname:', previousPathname);
 
-    const region_id = previousPathname.split('/').pop(); // 이전 URL의 마지막 부분
-    const regionId = region_id ? Number(region_id) : undefined; // 숫자로 변환
+      const region_id = previousPathname.split('/').pop(); // 이전 URL의 마지막 부분
+      const regionId = region_id ? Number(region_id) : undefined; // 숫자로 변환
 
-    setRegionIdNumber(regionId);
-    setIsBigPage(previousPathname.includes('/big')); // BigPage 여부 설정
+      console.log('Extracted regionId:', regionId);
+      setRegionIdNumber(regionId);
+      setIsBigPage(previousPathname.includes('/big'));
+    }
   }, []);
 
   const handleSaveClick = () => {
@@ -68,7 +72,6 @@ export default function Page() {
           if (isBigPage && regionIdNumber) {
             refetchBigCourse();
           }
-
           // SmallPage일 경우 SmallCourse refetch
           if (!isBigPage && regionIdNumber) {
             refetchSmallCourse();
@@ -90,6 +93,15 @@ export default function Page() {
     );
   };
 
+  const handleBackClick = () => {
+    console.log('Refetching for regionId:', regionIdNumber);
+    if (isBigPage) {
+      refetchBigCourse();
+    } else {
+      refetchSmallCourse();
+    }
+  };
+
   if (!courseResponse || !blogResponse) {
     return <></>;
   }
@@ -99,7 +111,12 @@ export default function Page() {
 
   return (
     <main className="relative flex h-full w-full flex-col">
-      <DetailsHeader title={course.name} isSaved={course.isSave} onClick={handleSaveClick} />
+      <DetailsHeader
+        title={course.name}
+        isSaved={course.isSave}
+        onClick={handleSaveClick}
+        onBackClick={handleBackClick}
+      />
       <section className="mt-68pxr flex flex-col pb-68pxr">
         <ImageContainer title={course.name} imgSrc={course.image} />
         <InfoContainer

--- a/footlog/src/app/(CommonLayout)/home/details/[id]/page.tsx
+++ b/footlog/src/app/(CommonLayout)/home/details/[id]/page.tsx
@@ -73,12 +73,12 @@ export default function page() {
       <section className="mt-68pxr flex flex-col pb-68pxr">
         <ImageContainer title={course.name} imgSrc={course.image} />
         <InfoContainer
-          description={course.summary}
+          summary={course.summary}
           address={course.address}
-          price="각 프로그램별로 이용요금 상이"
+          charge={course.charge === '정보 없음' ? '프로그램별로 이용요금 상이' : course.charge}
           time=""
-          call={course.tel}
-          site="홈페이지 / 웹사이트 URL"
+          tel={course.tel}
+          homepage={course.homepage === '정보 없음' ? '홈페이지 / 웹사이트 URL' : course.homepage}
         />
         <div className="h-8pxr w-full bg-gray-1" />
         <BlogContainer title={course.name} posting={posting} />

--- a/footlog/src/app/(CommonLayout)/home/list/big/[id]/page.tsx
+++ b/footlog/src/app/(CommonLayout)/home/list/big/[id]/page.tsx
@@ -7,6 +7,7 @@ import ListHeader from '@components/home/list/ListHeader';
 import useGetRegionalCourse from '@hooks/home/list/useGetRegionalCourse';
 import useGetRegions from '@hooks/home/useGetRegions';
 import { AreaCodeDtoDataTypes } from '@api/home/getRegions';
+import { useInfiniteScroll } from '@hooks/common/useInfiniteScroll';
 import { MoonLoader } from 'react-spinners';
 
 export default function Page() {
@@ -16,9 +17,7 @@ export default function Page() {
   const { data: regions } = useGetRegions();
   const [area_name, setAreaName] = useState<string>('');
   const [courses, setCourses] = useState<CourseResponseDtoDataTypes[]>([]);
-  const [visibleCount, setVisibleCount] = useState(10); // 초기 표시할 데이터 수
   const areaIdNumber = area_id ? Number(area_id) : 0;
-  const observer = useRef<IntersectionObserver | null>(null);
 
   // area_id에 맞는 area_name 찾기
   useEffect(() => {
@@ -34,39 +33,11 @@ export default function Page() {
   useEffect(() => {
     if (fetchedCourses?.data) {
       setCourses(fetchedCourses.data);
-      console.log('Fetched courses:', fetchedCourses.data); // 디버깅 로그
     }
   }, [fetchedCourses]);
 
-  // Intersection Observer 설정
-  useEffect(() => {
-    if (observer.current) {
-      observer.current.disconnect();
-    }
-
-    const loadMore = (entries: IntersectionObserverEntry[]) => {
-      if (entries[0].isIntersecting) {
-        setVisibleCount((prevCount) => Math.min(prevCount + 10, courses.length));
-      }
-    };
-
-    observer.current = new IntersectionObserver(loadMore, {
-      root: null, // viewport
-      rootMargin: '0px',
-      threshold: 1.0, // 100% 가시화
-    });
-
-    const target = document.querySelector('#load-more');
-    if (target) {
-      observer.current.observe(target);
-    }
-
-    return () => {
-      if (observer.current && target) {
-        observer.current.unobserve(target);
-      }
-    };
-  }, [courses]);
+  // 무한 스크롤 훅 사용
+  const { visibleCount } = useInfiniteScroll(courses.length, () => {});
 
   return (
     <main className="relative flex h-full w-full flex-col">

--- a/footlog/src/app/(CommonLayout)/home/list/big/[id]/page.tsx
+++ b/footlog/src/app/(CommonLayout)/home/list/big/[id]/page.tsx
@@ -19,6 +19,11 @@ export default function Page() {
   const [courses, setCourses] = useState<CourseResponseDtoDataTypes[]>([]);
   const areaIdNumber = area_id ? Number(area_id) : 0;
 
+  useEffect(() => {
+    // 현재 URL을 로컬스토리지에 저장
+    localStorage.setItem('previousUrl', window.location.href);
+  }, []);
+
   // area_id에 맞는 area_name 찾기
   useEffect(() => {
     if (regions?.data) {
@@ -42,7 +47,7 @@ export default function Page() {
   return (
     <main className="relative flex h-full w-full flex-col">
       <ListHeader title={area_name} />
-      <section className="mt-68pxr flex flex-col gap-24pxr pt-12pxr">
+      <section className="scroll-y-auto mt-68pxr flex flex-col gap-24pxr pt-12pxr">
         {courses.slice(0, visibleCount).map((course: CourseResponseDtoDataTypes) => (
           <section key={course.course_id}>
             <BigLocationCard course={course} />

--- a/footlog/src/app/(CommonLayout)/home/list/big/[id]/page.tsx
+++ b/footlog/src/app/(CommonLayout)/home/list/big/[id]/page.tsx
@@ -1,12 +1,13 @@
 'use client';
 import { usePathname } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useEffect, useState, useRef } from 'react';
 import { CourseResponseDtoDataTypes } from 'types/common/CommonTypes';
 import BigLocationCard from '@components/common/LocationCard/BigLocationCard';
 import ListHeader from '@components/home/list/ListHeader';
 import useGetRegionalCourse from '@hooks/home/list/useGetRegionalCourse';
 import useGetRegions from '@hooks/home/useGetRegions';
 import { AreaCodeDtoDataTypes } from '@api/home/getRegions';
+import { MoonLoader } from 'react-spinners';
 
 export default function Page() {
   const pathname = usePathname();
@@ -14,38 +15,74 @@ export default function Page() {
 
   const { data: regions } = useGetRegions();
   const [area_name, setAreaName] = useState<string>('');
+  const [courses, setCourses] = useState<CourseResponseDtoDataTypes[]>([]);
+  const [visibleCount, setVisibleCount] = useState(10); // 초기 표시할 데이터 수
   const areaIdNumber = area_id ? Number(area_id) : 0;
+  const observer = useRef<IntersectionObserver | null>(null);
 
   // area_id에 맞는 area_name 찾기
   useEffect(() => {
     if (regions?.data) {
-      if (areaIdNumber === 0) {
-        setAreaName('전체');
-      } else {
-        const foundRegion = regions.data.find((region: AreaCodeDtoDataTypes) => region.areaCode === areaIdNumber);
-        if (foundRegion) {
-          setAreaName(foundRegion.areaName);
-        } else {
-          setAreaName('전체');
-        }
-      }
+      const foundRegion = regions.data.find((region: AreaCodeDtoDataTypes) => region.areaCode === areaIdNumber);
+      setAreaName(foundRegion ? foundRegion.areaName : '전체');
     }
   }, [regions, areaIdNumber]);
 
-  const { data: courses } = useGetRegionalCourse(areaIdNumber);
+  // 코스 데이터 가져오기
+  const { data: fetchedCourses } = useGetRegionalCourse(areaIdNumber);
+
+  useEffect(() => {
+    if (fetchedCourses?.data) {
+      setCourses(fetchedCourses.data);
+      console.log('Fetched courses:', fetchedCourses.data); // 디버깅 로그
+    }
+  }, [fetchedCourses]);
+
+  // Intersection Observer 설정
+  useEffect(() => {
+    if (observer.current) {
+      observer.current.disconnect();
+    }
+
+    const loadMore = (entries: IntersectionObserverEntry[]) => {
+      if (entries[0].isIntersecting) {
+        setVisibleCount((prevCount) => Math.min(prevCount + 10, courses.length));
+      }
+    };
+
+    observer.current = new IntersectionObserver(loadMore, {
+      root: null, // viewport
+      rootMargin: '0px',
+      threshold: 1.0, // 100% 가시화
+    });
+
+    const target = document.querySelector('#load-more');
+    if (target) {
+      observer.current.observe(target);
+    }
+
+    return () => {
+      if (observer.current && target) {
+        observer.current.unobserve(target);
+      }
+    };
+  }, [courses]);
 
   return (
     <main className="relative flex h-full w-full flex-col">
       <ListHeader title={area_name} />
       <section className="mt-68pxr flex flex-col gap-24pxr pt-12pxr">
-        {courses &&
-          courses.data &&
-          courses.data.map((course: CourseResponseDtoDataTypes) => (
-            <section key={course.course_id}>
-              <BigLocationCard course={course} />
-              <div className="h-8pxr w-full bg-gray-1" />
-            </section>
-          ))}
+        {courses.slice(0, visibleCount).map((course: CourseResponseDtoDataTypes) => (
+          <section key={course.course_id}>
+            <BigLocationCard course={course} />
+            <div className="h-8pxr w-full bg-gray-1" />
+          </section>
+        ))}
+        {visibleCount < courses.length && (
+          <div id="load-more" className="flex items-center justify-center">
+            <MoonLoader color="#05cbbe" size={20} speedMultiplier={0.5} />
+          </div>
+        )}
       </section>
     </main>
   );

--- a/footlog/src/app/(CommonLayout)/home/list/big/[id]/page.tsx
+++ b/footlog/src/app/(CommonLayout)/home/list/big/[id]/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 import { usePathname } from 'next/navigation';
-import { useEffect, useState, useRef } from 'react';
+import { useEffect, useState } from 'react';
 import { CourseResponseDtoDataTypes } from 'types/common/CommonTypes';
 import BigLocationCard from '@components/common/LocationCard/BigLocationCard';
 import ListHeader from '@components/home/list/ListHeader';

--- a/footlog/src/app/(CommonLayout)/home/list/small/[id]/page.tsx
+++ b/footlog/src/app/(CommonLayout)/home/list/small/[id]/page.tsx
@@ -46,16 +46,22 @@ export default function Page() {
     <main className="relative flex h-full w-full flex-col">
       <ListHeader title={area_name} />
       <section className="mt-68pxr flex flex-col gap-24pxr pt-12pxr">
-        {courses.slice(0, visibleCount).map((course: CourseResponseDtoDataTypes) => (
-          <section key={course.course_id}>
-            <BigLocationCard course={course} />
-            <div className="h-8pxr w-full bg-gray-1" />
-          </section>
-        ))}
-        {visibleCount < courses.length && (
-          <div id="load-more" className="flex items-center justify-center">
-            <MoonLoader color="#05cbbe" size={20} speedMultiplier={0.5} />
-          </div>
+        {courses.length === 0 ? ( // 코스가 없는 경우 메시지 출력
+          <p className="fonts-recommendSubtitle mt-289pxr flex justify-center">해당 지역의 코스가 없습니다.</p>
+        ) : (
+          <>
+            {courses.slice(0, visibleCount).map((course: CourseResponseDtoDataTypes) => (
+              <section key={course.course_id}>
+                <BigLocationCard course={course} />
+                <div className="h-8pxr w-full bg-gray-1" />
+              </section>
+            ))}
+            {visibleCount < courses.length && (
+              <div id="load-more" className="flex items-center justify-center">
+                <MoonLoader color="#05cbbe" size={20} speedMultiplier={0.5} />
+              </div>
+            )}
+          </>
         )}
       </section>
     </main>

--- a/footlog/src/app/(CommonLayout)/home/list/small/[id]/page.tsx
+++ b/footlog/src/app/(CommonLayout)/home/list/small/[id]/page.tsx
@@ -5,9 +5,10 @@ import { CourseResponseDtoDataTypes } from 'types/common/CommonTypes';
 import { CityRegionsDtoDataTypes } from 'types/home/search/SearchTypes';
 import BigLocationCard from '@components/common/LocationCard/BigLocationCard';
 import ListHeader from '@components/home/list/ListHeader';
-import useGetRegionalCourse from '@hooks/home/list/useGetRegionalCourse';
 import useGetCityRegions from '@hooks/home/search/useGetCityRegions';
 import useGetCityCourse from '@hooks/home/list/useGetCityCourse';
+import { useInfiniteScroll } from '@hooks/common/useInfiniteScroll';
+import { MoonLoader } from 'react-spinners';
 
 export default function Page() {
   const pathname = usePathname();
@@ -15,6 +16,7 @@ export default function Page() {
 
   const { data: regions } = useGetCityRegions();
   const [area_name, setAreaName] = useState<string>('');
+  const [courses, setCourses] = useState<CourseResponseDtoDataTypes[]>([]);
   const areaIdNumber = area_id ? Number(area_id) : 0;
 
   // sigunguId에 맞는 sigunguName 찾기
@@ -29,20 +31,32 @@ export default function Page() {
     }
   }, [regions, areaIdNumber]);
 
-  const { data: courses } = useGetCityCourse(areaIdNumber);
+  const { data: fetchedCourses } = useGetCityCourse(areaIdNumber);
+
+  useEffect(() => {
+    if (fetchedCourses?.data) {
+      setCourses(fetchedCourses.data);
+    }
+  }, [fetchedCourses]);
+
+  // 무한 스크롤 훅 사용
+  const { visibleCount } = useInfiniteScroll(courses.length, () => {});
 
   return (
     <main className="relative flex h-full w-full flex-col">
       <ListHeader title={area_name} />
       <section className="mt-68pxr flex flex-col gap-24pxr pt-12pxr">
-        {courses &&
-          courses.data &&
-          courses.data.map((course: CourseResponseDtoDataTypes) => (
-            <section key={course.course_id}>
-              <BigLocationCard course={course} />
-              <div className="h-8pxr w-full bg-gray-1" />
-            </section>
-          ))}
+        {courses.slice(0, visibleCount).map((course: CourseResponseDtoDataTypes) => (
+          <section key={course.course_id}>
+            <BigLocationCard course={course} />
+            <div className="h-8pxr w-full bg-gray-1" />
+          </section>
+        ))}
+        {visibleCount < courses.length && (
+          <div id="load-more" className="flex items-center justify-center">
+            <MoonLoader color="#05cbbe" size={20} speedMultiplier={0.5} />
+          </div>
+        )}
       </section>
     </main>
   );

--- a/footlog/src/app/(CommonLayout)/home/search/results/page.tsx
+++ b/footlog/src/app/(CommonLayout)/home/search/results/page.tsx
@@ -8,6 +8,8 @@ import { CourseResponseDtoDataTypes } from 'types/common/CommonTypes';
 import useGetRegionalCourse from '@hooks/home/list/useGetRegionalCourse';
 import useGetSearchResult from '@hooks/home/search/useGetSearchResult';
 import useGetCityRegions from '@hooks/home/search/useGetCityRegions';
+import { useInfiniteScroll } from '@hooks/common/useInfiniteScroll';
+import { MoonLoader } from 'react-spinners';
 
 export default function Page() {
   const router = useRouter();

--- a/footlog/src/app/(CommonLayout)/mypage/page.tsx
+++ b/footlog/src/app/(CommonLayout)/mypage/page.tsx
@@ -6,7 +6,6 @@ import useGetSaveCourseList from '@hooks/mypage/useGetSaveCourseList';
 import useGetRecentCourse from '@hooks/common/useGetRecentCourse';
 import useGetUserInfo from '@hooks/mypage/useGetUserInfo';
 import React, { useEffect, useState } from 'react';
-import { useRecoilCallback } from 'recoil';
 import useDeleteUser from '@hooks/mypage/useDeleteUser';
 import { useRouter } from 'next/navigation';
 

--- a/footlog/src/app/globals.css
+++ b/footlog/src/app/globals.css
@@ -351,3 +351,12 @@ button {
   line-height: 1.5rem; /* 171.429% */
   letter-spacing: -0.03125rem;
 }
+
+.fonts-searchingCourse {
+  font-family: 'Noto Sans KR';
+  font-size: 1rem;
+  font-style: normal;
+  font-weight: 400;
+  line-height: 130%; /* 20.8px */
+  letter-spacing: -0.03125rem;
+}

--- a/footlog/src/components/common/LocationCard/BigLocationCard.tsx
+++ b/footlog/src/components/common/LocationCard/BigLocationCard.tsx
@@ -67,7 +67,7 @@ export default function BigLocationCard(props: LocationCardProps) {
         passHref
         className="flex cursor-pointer flex-col gap-20pxr">
         <section className="flex flex-col items-start gap-4pxr">
-          <p className="fonts-recommendTitle">{course.name}</p>
+          <p className="fonts-recommendTitle w-[92%]">{course.name}</p>
           <p className="fonts-detail">{course.area}</p>
         </section>
         <figure className="relative flex h-148pxr w-345pxr overflow-hidden rounded-xl">

--- a/footlog/src/components/common/LocationCard/LocationCard.tsx
+++ b/footlog/src/components/common/LocationCard/LocationCard.tsx
@@ -11,7 +11,7 @@ export default function LocationCard(props: LocationCardProps) {
       key={course.course_id}
       href={`/home/details/${course.course_id}`}
       passHref
-      className="flex cursor-pointer items-center gap-16pxr pl-24pxr">
+      className="flex cursor-pointer items-center gap-16pxr px-24pxr">
       <figure className="relative flex h-64pxr w-64pxr overflow-hidden rounded-xl">
         <Image
           fill
@@ -23,7 +23,7 @@ export default function LocationCard(props: LocationCardProps) {
         />
       </figure>
       <section className="flex flex-col items-start gap-4pxr">
-        <p className="fonts-onboardingKeyword text-gray-8">
+        <p className="fonts-searchingCourse text-gray-8">
           {highlightSearchTerm(course.name, searchInput || '')} {/* 강조된 이름 출력 */}
         </p>
         <p className="fonts-detail">{course.area}</p>

--- a/footlog/src/components/common/RecentCourseContainer/RecentCourseContainer.tsx
+++ b/footlog/src/components/common/RecentCourseContainer/RecentCourseContainer.tsx
@@ -14,7 +14,7 @@ export default function RecentCourseContainer(props: CoursesDataTypes) {
       <section className="flex items-center">
         {courses.length === 0 ? (
           isMyPage ? (
-            <p className="fonts-recommendSubtitle mb-57pxr justify-center">최근 확인한 코스가 없습니다.</p>
+            <p className="fonts-recommendSubtitle mb-57pxr mt-71pxr justify-center">최근 확인한 코스가 없습니다.</p>
           ) : (
             <p className="fonts-recommendSubtitle flex pt-20pxr">최근 확인한 코스가 없습니다.</p>
           )

--- a/footlog/src/components/common/RecentCourseContainer/RecentCourseContainer.tsx
+++ b/footlog/src/components/common/RecentCourseContainer/RecentCourseContainer.tsx
@@ -14,7 +14,7 @@ export default function RecentCourseContainer(props: CoursesDataTypes) {
       <section className="flex items-center">
         {courses.length === 0 ? (
           isMyPage ? (
-            <p className="fonts-recommendSubtitle mb-57pxr ml-92pxr mt-71pxr">최근 확인한 코스가 없습니다.</p>
+            <p className="fonts-recommendSubtitle mb-57pxr justify-center">최근 확인한 코스가 없습니다.</p>
           ) : (
             <p className="fonts-recommendSubtitle flex pt-20pxr">최근 확인한 코스가 없습니다.</p>
           )

--- a/footlog/src/components/home/details/DetailsHeader.tsx
+++ b/footlog/src/components/home/details/DetailsHeader.tsx
@@ -20,11 +20,11 @@ export default function DetailsHeader(props: DetailsHeaderProps) {
 
   return (
     <section className="fixed top-0 z-20 flex h-68pxr w-full items-center justify-between bg-white px-24pxr">
-      <button type="button" className="cursor-pointer" onClick={() => handleBackBtn()}>
+      <button type="button" className="cursor-pointer pr-15pxr" onClick={() => handleBackBtn()}>
         <LeftArrowIcon />
       </button>
       <p className="fonts-recommendTitle">{title}</p>
-      <button type="button" className="cursor-pointer" onClick={onClick}>
+      <button type="button" className="cursor-pointer px-15pxr" onClick={onClick}>
         {isSaved ? <SaveFilledGreenIcon /> : <SaveOutlineGreenIcon />}
       </button>
     </section>

--- a/footlog/src/components/home/details/DetailsHeader.tsx
+++ b/footlog/src/components/home/details/DetailsHeader.tsx
@@ -6,14 +6,16 @@ interface DetailsHeaderProps {
   title: string;
   isSaved: boolean;
   onClick: () => void;
+  onBackClick: () => void;
 }
 
 export default function DetailsHeader(props: DetailsHeaderProps) {
-  const { title, isSaved, onClick } = props;
+  const { title, isSaved, onClick, onBackClick } = props;
   const router = useRouter();
   const { refetch: refetchRecentCourse } = useGetRecentCourse();
 
   const handleBackBtn = async () => {
+    onBackClick();
     await Promise.all([refetchRecentCourse()]);
     router.back();
   };

--- a/footlog/src/components/home/details/InfoContainer.tsx
+++ b/footlog/src/components/home/details/InfoContainer.tsx
@@ -2,43 +2,52 @@ import { useState } from 'react';
 import { LocationIcon, PriceIcon, ClockIcon, CallIcon, SiteIcon } from '@public/icon';
 
 interface InfoContainerProps {
-  description: string;
+  summary: string;
   address: string;
-  price: string;
+  charge: string;
   time: string;
-  call: string;
-  site: string;
+  tel: string;
+  homepage: string;
+}
+
+interface InfoContainerProps {
+  summary: string;
+  address: string;
+  charge: string;
+  time: string;
+  tel: string;
+  homepage: string;
 }
 
 export default function InfoContainer(props: InfoContainerProps) {
-  const { description, address, price, time, call, site } = props;
+  const { summary, address, charge, time, tel, homepage } = props;
   const [isExpanded, setIsExpanded] = useState(false);
 
   const infoItems = [
     { icon: <LocationIcon />, text: address },
-    { icon: <PriceIcon />, text: price },
+    { icon: <PriceIcon />, text: charge },
     { icon: <ClockIcon />, text: time },
-    { icon: <CallIcon />, text: call },
-    { icon: <SiteIcon />, text: site },
+    { icon: <CallIcon />, text: tel },
+    { icon: <SiteIcon />, text: homepage },
   ];
 
   const toggleDescription = () => {
     setIsExpanded(!isExpanded); // 펼침 상태 토글
   };
 
-  // 설명이 너무 길지 않은 경우 더보기 버튼을 숨기기 위함
-  const isDescriptionLong = description.split('\n').length > 5;
+  // 150자를 기준으로 표시할 내용을 결정
+  const isDescriptionLong = summary.length > 150;
+  const displayedSummary = isExpanded ? summary : summary.slice(0, 150);
 
   return (
     <section className="flex w-full flex-col px-24pxr pt-20pxr">
       <p className={`fonts-detailDescription text-gray-8 ${!isExpanded ? 'line-clamp-5' : ''}`}>
-        {isExpanded ? description : `${description.slice(0, 154)}`}
+        {displayedSummary}
         {isDescriptionLong && !isExpanded && (
           <span className="fonts-detailDescription cursor-pointer text-gray-4" onClick={toggleDescription}>
             {' ...더보기'}
           </span>
         )}
-
         {isExpanded && (
           <span className="fonts-detailDescription cursor-pointer text-gray-4" onClick={toggleDescription}>
             {' ...접기'}
@@ -47,7 +56,7 @@ export default function InfoContainer(props: InfoContainerProps) {
       </p>
       <section className="mb-25pxr mt-20pxr flex flex-col gap-12pxr">
         {infoItems.map((item, index) => (
-          <section key={index} className="flex gap-12pxr">
+          <section key={index} className="flex items-center gap-12pxr">
             {item.icon}
             <p className="fonts-detail">{item.text}</p>
           </section>

--- a/footlog/src/components/home/details/InfoContainer.tsx
+++ b/footlog/src/components/home/details/InfoContainer.tsx
@@ -57,7 +57,7 @@ export default function InfoContainer(props: InfoContainerProps) {
       <section className="mb-25pxr mt-20pxr flex flex-col gap-12pxr">
         {infoItems.map((item, index) => (
           <section key={index} className="flex items-center gap-12pxr">
-            {item.icon}
+            <div className="flex">{item.icon}</div>
             <p className="fonts-detail">{item.text}</p>
           </section>
         ))}

--- a/footlog/src/components/home/details/InfoContainer.tsx
+++ b/footlog/src/components/home/details/InfoContainer.tsx
@@ -32,7 +32,7 @@ export default function InfoContainer(props: InfoContainerProps) {
   ];
 
   const toggleDescription = () => {
-    setIsExpanded(!isExpanded); // 펼침 상태 토글
+    setIsExpanded(!isExpanded);
   };
 
   // 150자를 기준으로 표시할 내용을 결정

--- a/footlog/src/components/home/search/RecentSearchContainer.tsx
+++ b/footlog/src/components/home/search/RecentSearchContainer.tsx
@@ -1,3 +1,4 @@
+import Link from 'next/link';
 import { CloseIcon } from '@public/icon';
 import { SearchLogDtoDataTypes } from 'types/home/search/SearchTypes';
 import usePatchRecentSearch from '@hooks/home/search/usePatchRecentSearch';
@@ -31,14 +32,14 @@ export default function RecentSearchContainer(props: RecentSearchContainerProps)
           <p className="fonts-recommendSubtitle flex">최근 검색어가 존재하지 않습니다.</p>
         ) : (
           recentSearch.map((search) => (
-            <div
-              key={search.keyword}
-              className="flex h-36pxr w-auto items-center justify-center gap-12pxr rounded-searchBox border border-gray-2 px-16pxr">
-              <span className="fonts-recommendSubtitle flex-1 whitespace-nowrap">{search.keyword}</span>
-              <button type="button" className="cursor-pointer" onClick={() => handleDeleteClick(search.keyword)}>
-                <CloseIcon />
-              </button>
-            </div>
+            <Link key={search.keyword} href={`search/results?query=${encodeURIComponent(search.keyword)}`} passHref>
+              <div className="flex h-36pxr w-auto items-center justify-center gap-12pxr rounded-searchBox border border-gray-2 px-16pxr">
+                <span className="fonts-recommendSubtitle flex-1 whitespace-nowrap">{search.keyword}</span>
+                <button type="button" className="cursor-pointer" onClick={() => handleDeleteClick(search.keyword)}>
+                  <CloseIcon />
+                </button>
+              </div>
+            </Link>
           ))
         )}
       </section>

--- a/footlog/src/components/home/search/results/SearchedResults.tsx
+++ b/footlog/src/components/home/search/results/SearchedResults.tsx
@@ -3,6 +3,8 @@ import BigLocationCard from '@components/common/LocationCard/BigLocationCard';
 import RegionCard from '../RegionCard';
 import { CityRegionsDtoDataTypes } from 'types/home/search/SearchTypes';
 import { CourseResponseDtoDataTypes } from 'types/common/CommonTypes';
+import { useInfiniteScroll } from '@hooks/common/useInfiniteScroll';
+import { MoonLoader } from 'react-spinners';
 
 interface SearchResultsProps {
   filteredCourses: CourseResponseDtoDataTypes[];

--- a/footlog/src/components/log/MarkerModal.tsx
+++ b/footlog/src/components/log/MarkerModal.tsx
@@ -1,4 +1,4 @@
-import { Blank, BlankPlus, LogCloseBtn, RemoveBtn } from '@public/icon';
+import { Blank, LogCloseBtn, RemoveBtn } from '@public/icon';
 import React, { useEffect, useState } from 'react';
 
 interface MarkerModalProps {

--- a/footlog/src/hooks/common/useInfiniteScroll.ts
+++ b/footlog/src/hooks/common/useInfiniteScroll.ts
@@ -1,0 +1,38 @@
+import { useEffect, useRef, useState } from 'react';
+
+export const useInfiniteScroll = (dataLength: number, loadMore: () => void) => {
+  const [visibleCount, setVisibleCount] = useState(10);
+  const observer = useRef<IntersectionObserver | null>(null);
+
+  useEffect(() => {
+    if (observer.current) {
+      observer.current.disconnect();
+    }
+
+    const loadMoreHandler = (entries: IntersectionObserverEntry[]) => {
+      if (entries[0].isIntersecting) {
+        setVisibleCount((prevCount) => Math.min(prevCount + 10, dataLength));
+        loadMore(); // 데이터 로드 함수 호출
+      }
+    };
+
+    observer.current = new IntersectionObserver(loadMoreHandler, {
+      root: null, // viewport
+      rootMargin: '0px',
+      threshold: 1.0, // 100% 가시화
+    });
+
+    const target = document.querySelector('#load-more');
+    if (target) {
+      observer.current.observe(target);
+    }
+
+    return () => {
+      if (observer.current && target) {
+        observer.current.unobserve(target);
+      }
+    };
+  }, [dataLength, loadMore]);
+
+  return { visibleCount };
+};

--- a/footlog/src/recoil/atom.ts
+++ b/footlog/src/recoil/atom.ts
@@ -1,7 +1,6 @@
 'use client';
 import { atom } from 'recoil';
 
-/*온보딩 정보 post를 위한*/
 export const firstOnboardingState = atom<string[]>({
   key: 'firstOnboardingState',
   default: [],

--- a/footlog/src/types/home/details/DetailsTypes.ts
+++ b/footlog/src/types/home/details/DetailsTypes.ts
@@ -1,19 +1,3 @@
-import { StaticImageData } from 'next/image';
-
-export interface CourseDetailsDataTypes {
-  id: number;
-  title: string;
-  isSaved: boolean;
-  imgSrc: StaticImageData;
-  description: string;
-  address: string;
-  price: string;
-  time: string;
-  call: string;
-  site: string;
-  isComplete: boolean;
-}
-
 export interface RequestPathVariable {
   course_id: number;
 }

--- a/footlog/src/utils/highlightSearchTerm.tsx
+++ b/footlog/src/utils/highlightSearchTerm.tsx
@@ -1,6 +1,6 @@
 // 검색어가 있을 때 강조할 텍스트 생성
 export const highlightSearchTerm = (text: string, search: string) => {
-  if (!search) return <span>{text}</span>; // 검색어가 없으면 원래 텍스트 반환
+  if (!search) return <span>{text}</span>;
 
   const regex = new RegExp(`(${search})`, 'gi'); // 대소문자를 구분하지 않도록 정규 표현식 생성
   const parts = text.split(regex); // 텍스트를 검색어로 분리


### PR DESCRIPTION
## Related Issues

- close #37 

## PR 유형

어떤 변경 사항이 있나요?

- [x] 새로운 기능 추가
- [x] 오류 수정

## 변경 사항 in Detail



https://github.com/user-attachments/assets/b50ef39b-1111-4664-bb96-3c58f6b876b9



- [x] 지역 목록, 시군구 목록에 무한 스크롤 기능 추가
  - Web API인 `IntersectionObserver`를 사용해서 무한스크롤을 적용했어!

  - 목록 내부에서 유저가 스크롤하여 10개의 코스들을 확인하고 스피너가 뷰포트에 들어오면 loadMore() 데이터 로드 함수를 호출해 다음 10개를 추가로 코스를 가져오는 형식으로 구현했어!

  - 아래와 같이 useInfiniteScroll 훅으로 분리해놨옹
  - 스크롤 위치 기억해놨다가 복원하는 코드도 작성해봤는데 아무리 해도 안되는 거야.. 찾아보니까 body에 height:100%를 해놔서 그런 거래. ㅜㅜ 근데 100%를 안해놓으면 핸드폰 기종마다 뷰가 조금씩 달라질 것 같아서 ......... 이건 보류.. 해야할 것 같다 다시 알아볼게 ㅠㅠ
```
import { useEffect, useRef, useState } from 'react';

export const useInfiniteScroll = (dataLength: number, loadMore: () => void) => {
  const [visibleCount, setVisibleCount] = useState(10);
  const observer = useRef<IntersectionObserver | null>(null);

  useEffect(() => {
    if (observer.current) {
      observer.current.disconnect();
    }

    const loadMoreHandler = (entries: IntersectionObserverEntry[]) => {
      if (entries[0].isIntersecting) {
        setVisibleCount((prevCount) => Math.min(prevCount + 10, dataLength));
        loadMore(); // 데이터 로드 함수 호출
      }
    };

    observer.current = new IntersectionObserver(loadMoreHandler, {
      root: null, // viewport
      rootMargin: '0px',
      threshold: 1.0, // 100% 가시화
    });

    const target = document.querySelector('#load-more');
    if (target) {
      observer.current.observe(target);
    }

    return () => {
      if (observer.current && target) {
        observer.current.unobserve(target);
      }
    };
  }, [dataLength, loadMore]);

  return { visibleCount };
};

```

- [x] 코스가 없는 시군구의 경우 문구 출력

<img src="https://github.com/user-attachments/assets/d4ddd655-e14a-4613-8aad-7d0672c0c909" alt="image" width="300"/>



## 다음에 할 것

- [ ] 마이페이지 최근 확인한 코스에서 저장 시 저장 목록에 적용 안되는 문제 해결
